### PR TITLE
Fix deprecation warnings

### DIFF
--- a/tasks/system_packages.yml
+++ b/tasks/system_packages.yml
@@ -5,15 +5,15 @@
 
 - name: ensure pre-defined default packages present
   yum:
-    name: "{{ item }}"
+    name: '{{ item }}'
     state: present
-  with_items: __system_packages
+  with_items: '{{ __system_packages }}'
 
 - name: ensure user-defined basic packages present
   yum:
-    name: "{{ item }}"
+    name: '{{ item }}'
     state: present
-  with_items: system_packages
+  with_items: '{{ system_packages }}'
   when: system_packages is defined
 
 # Install MySQL related packages
@@ -25,7 +25,7 @@
 
 - name: ensure mysql-devel present
   yum:
-    name: "{{ item }}"
+    name: '{{ item }}'
     state: present
   with_items:
     - mysql55


### PR DESCRIPTION
## Summary of changes

Use full variable syntax to avoid deprecation warnings.
## How to Test
1. Use this in requirements file:
   
   ``` yml
   - src: git@github.com:tjoelsson/ansible-role-common
     scm: git
     version: 1dcebf0
     name: juwai.common
   ```
2. Run playbook using juwai.common
3. Don't see deprecation warning
