### PR TITLE
Remove tig from system packages

### DIFF
--- a/vars/packages.yml
+++ b/vars/packages.yml
@@ -10,4 +10,3 @@ __system_packages:
   - vim
   - mlocate
   - tree
-  - tig


### PR DESCRIPTION
## Summary of changes

Remove tig from system packages. It fails to install and I don't think it's required.

## How to Test

Run a playbook that includes this role.