### PR TITLE
Don't use webtatic repo in amazon linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 Ansible Role: Common
 =========
 
-Configure locale/repo/timezone and install some necessary packages on CentOS servers.
+Configure locale/repo/timezone and install some necessary packages on CentOS or Amazon Linux.
 
 Requirements
 ------------
 
-Written in Ansible 1.9.*
+Written in Ansible 2.3.*
 
 Role Variables
 --------------

--- a/tasks/repo.yml
+++ b/tasks/repo.yml
@@ -3,7 +3,7 @@
   yum:
     name: https://mirror.webtatic.com/yum/el6/latest.rpm
     state: present
-  when: env == 'vagrant'
+  when: ansible_distribution != 'Amazon'
 
 - name: update packages
   yum:

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+test.retry

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -1,0 +1,26 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.ssh.insert_key = false
+  config.ssh.forward_agent = true
+  config.ssh.host = 'localhost'
+  config.ssh.port = '2250'
+  config.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
+
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.provider :docker do |docker|
+    docker.image = 'juwaicom/amazonlinux-vagrant:1.0'
+    docker.force_host_vm = false
+    docker.has_ssh = true
+    docker.ports = [
+        '2250:22',
+    ]
+  end
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.verbose = "v"
+    ansible.playbook = "test.yml"
+  end
+end

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,6 @@
+---
+- hosts: default
+  remote_user: vagrant
+  become: yes
+  roles:
+    - common


### PR DESCRIPTION
## Summary of changes

- Don't use webtatic repo in amazon linux
- Use docker instead of virtualbox for testing

## How to Test

1. `$ cd tests/`
1. `$ vagrant up`