### PR TITLE
Make ready for Amazon Linux 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Note: this won't override pre-defined `__system_packages`.
 
 ### env
 
-Define env to `vagrant` would install webtatic repo.
+Environment name.
 
 Default is `vagrant`.
 

--- a/tasks/system_packages.yml
+++ b/tasks/system_packages.yml
@@ -5,15 +5,13 @@
 
 - name: ensure pre-defined default packages present
   yum:
-    name: '{{ item }}'
+    name: '{{ __system_packages }}'
     state: present
-  with_items: '{{ __system_packages }}'
 
 - name: ensure user-defined basic packages present
   yum:
-    name: '{{ item }}'
+    name: '{{ system_packages }}'
     state: present
-  with_items: '{{ system_packages }}'
   when: system_packages is defined
 
 # Install MySQL package

--- a/tasks/system_packages.yml
+++ b/tasks/system_packages.yml
@@ -16,23 +16,8 @@
   with_items: '{{ system_packages }}'
   when: system_packages is defined
 
-# Install MySQL related packages
+# Install MySQL package
 - name: ensure mysql-devel present
   yum:
     name: mysql-devel
     state: present
-  when: ansible_distribution != 'Amazon'
-
-- name: ensure mysql-devel present
-  yum:
-    name: '{{ item }}'
-    state: present
-  with_items:
-    - mysql55
-    - mysql55-devel
-  when: ansible_distribution == 'Amazon'
-
-- name: ensure latest version of curl is installed
-  yum:
-    name: curl
-    state: latest

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.provider :docker do |docker|
-    docker.image = 'juwaicom/amazonlinux-vagrant:1.0'
+    docker.image = 'juwaicom/amazonlinux-vagrant:2.0'
     docker.force_host_vm = false
     docker.has_ssh = true
     docker.ports = [


### PR DESCRIPTION
## Summary of changes

- Remove special case for mysql package name
- Remove task to get latest curl. This is no longer necessary and increases time to run playbooks.
- Fix the deprecation warning
- Use Amazon Linux 2 in test
- Fix mistake in readme

## How to Test

1. Build docker image from here https://github.com/juwai/docker-images/pull/2
1. Go to tests/ folder
2. Run: `$ vagrant up`
3. See no error